### PR TITLE
adding cards to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,39 +230,117 @@
       </div>
     </div>
     
-   <!-- new card in a container -->
+ <!-- new card in a container -->
     
-    <div class=" container mx-auto w-auto px-5 py-24 flex flex-inline">
-        <div class="lg:w-1/2 bg-yellow-200 flex flex-inline">
-            <div class="lg:w-2/5 bg-green-200">
-                <h2>IMAGE</h2>
-            </div>
-            <div class="lg:w-3/4 px-5 pt-1 bg-green-500">
-                <h1 class="font-medium text-xl pt-8">awesome-github-profiles</h1>
-                <p class="font-light text-sm py-1">List of GitHub profiles that have awesome
-                    customisation, that you can use for inspiration.</p>
-                <ul class="lg:pb-5 lg:pt-2 ">
-                    <li class="py-1 flex flex-inline">
-                        <i class="fa fa-link"></i>
-                        <a class="pl-2" href="#">view repo</a>
-                    </li>
-                    <li class="py-1 flex flex-inline">
-                        <i class="fa fa-link"></i>
-                        <a class="pl-2" href="#">view website</a>
-                    </li>
-                    <li class="py-1 flex flex-inline">
-                        <i class="fa fa-link"></i>
-                        <a class="pl-2" href="#">tech lsit</a>
-                    </li>
-                </ul>
-            </div>
+    <div class="container mx-auto py-24 px-5">
+    <div class=" grid grid-cols-1 gap-5 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-1 xl:grid-cols-2">
+      
+      <!-- card 1  -->
 
+      <div class="bg-gray-0 h-32 md:h-48 lg:h-48">
+        <div class="flex flex-inline ">
+          <div class=" h-32 w-32 lg:h-48 lg:w-48 md:h-48 md:w-48 ">
+            <img class="rounded-full" src="https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?crop=entropy&cs=tinysrgb&fit=crop&fm=jpg&h=500&ixid=eyJhcHBfaWQiOjF9&ixlib=rb-1.2.1&q=80&w=500" alt="">
+          </div>
+          <div class=" lg:w-2/3 md:w-2/3 sm:w-2/3  px-5 pt-5 sm:pt-2 lg:pt-5 rounded-r-lg">
+            <button class="bg-yellow-400 rounded px-1 text-white text-sm ml-auto"> community </button>
+            <h1
+              class="font-medium text-lg sm:text-xl md:text-xl lg:text-xl xl:text-xl font-medium pt-2 sm:pt-1 md:pt-1 lg:pt-1">
+              Eddie Jaoude</h1>
+            <p
+              class="font-light text-xs sm:text-sm md:text-sm lg:text-sm xl:text-sm py-1 font-normal hidden   md:block lg:block break-words">
+              Fullstack open source DevRel! I love code and the community :). GitHub Star ⭐ program 🤓</p>
+            <div class=" hidden lg:inline-flex  md:inline-flex  flex flex-inline">
+              <div class="flex flex-inline">
+                <i class="fa fa-github-alt pr-1 pt-6 "
+                  style="font-size:18px; color:rgb(109, 71, 199); font-style:normal;"></i> </i>
+                <p class="pr-5 pt-5 text-purple-500 text-lg font-medium">
+                  website</p>
+              </div>
+              <div class="flex flex-inline">
+                <i class="fa fa-code-fork pr-1 pt-6 "
+                  style="font-size:18px; color:rgb(109, 71, 199); font-style:normal;"></i> </i>
+                <p class="pr-5 pt-5 text-purple-500 text-lg font-medium">
+                  repo</p>
+              </div>
+              <div class="flex inline-flex">
+                <i class="fa fa-star pr-1 pt-6 "
+                  style="font-size:16px; color:rgb(109, 71, 199); font-style:normal;"></i> </i>
+                <p class="pr-5 pt-5 text-purple-500 text-lg font-medium">
+                  star</p>
+              </div>
+            </div>
+            <!-- for small screens -->
+            <div class="flex-inline lg:hidden sm:flex-inline md:hidden flex flex-inline">
+              <div>
+                <i class="fa fa-github-alt pt-5 pr-5" style="font-size:20px; color:rgb(109, 71, 199);"></i>
+              </div>
+              <div>
+                <i class="fa fa-code-fork pt-5 pr-5" style="font-size:20px; color:rgb(109, 71, 199);"></i>
+              </div>
+              <div>
+                <i class="fa fa-star pt-5 pr-1" style="font-size:18px; color:rgb(109, 71, 199)"></i>
+              </div>
+            </div>
+          </div>
         </div>
-        <div class="lg:w-1/2 bg-pink-200">
-            <h2>SPACE</h2>
+      </div>
 
+      <!-- card 2  -->
+
+      <div class="bg-gray-0 h-32 md:h-48 lg:h-48">
+        <div class="flex flex-inline ">
+          <div class=" h-32 w-32 lg:h-48 lg:w-48 md:h-48 md:w-48 ">
+            <img class="rounded-full" src="https://images.unsplash.com/photo-1586297135537-94bc9ba060aa?crop=entropy&cs=tinysrgb&fit=crop&fm=jpg&h=500&ixid=eyJhcHBfaWQiOjF9&ixlib=rb-1.2.1&q=80&w=500" alt="">
+          </div>
+          <div class=" lg:w-2/3 md:w-2/3 sm:w-2/3  px-5 pt-5 sm:pt-2 lg:pt-5 rounded-r-lg">
+            <button class="bg-yellow-400 rounded px-1 text-white text-sm ml-auto"> community </button>
+            <h1
+              class="font-medium text-lg sm:text-xl md:text-xl lg:text-xl xl:text-xl font-medium pt-2 sm:pt-1 md:pt-1 lg:pt-1">
+              Eddie Jaoude</h1>
+            <p
+              class="font-light text-xs sm:text-sm md:text-sm lg:text-sm xl:text-sm py-1 font-normal hidden   md:block lg:block break-words">
+              Fullstack open source DevRel! I love code and the community :). GitHub Star ⭐ program 🤓</p>
+            <div class=" hidden lg:inline-flex  md:inline-flex  flex flex-inline">
+              <div class="flex flex-inline">
+                <i class="fa fa-github-alt pr-1 pt-6 "
+                  style="font-size:18px; color:rgb(109, 71, 199); font-style:normal;"></i> </i>
+                <p class="pr-5 pt-5 text-purple-500 text-lg font-medium">
+                  website</p>
+              </div>
+              <div class="flex flex-inline">
+                <i class="fa fa-code-fork pr-1 pt-6 "
+                  style="font-size:18px; color:rgb(109, 71, 199); font-style:normal;"></i> </i>
+                <p class="pr-5 pt-5 text-purple-500 text-lg font-medium">
+                  repo</p>
+              </div>
+              <div class="flex inline-flex">
+                <i class="fa fa-star pr-1 pt-6 "
+                  style="font-size:16px; color:rgb(109, 71, 199); font-style:normal;"></i> </i>
+                <p class="pr-5 pt-5 text-purple-500 text-lg font-medium">
+                  star</p>
+              </div>
+            </div>
+            <!-- for small screens -->
+            <div class="flex-inline lg:hidden sm:flex-inline md:hidden flex flex-inline">
+              <div>
+                <i class="fa fa-github-alt pt-5 pr-5" style="font-size:20px; color:rgb(109, 71, 199);"></i>
+              </div>
+              <div>
+                <i class="fa fa-code-fork pt-5 pr-5" style="font-size:20px; color:rgb(109, 71, 199);"></i>
+              </div>
+              <div>
+                <i class="fa fa-star pt-5 pr-1" style="font-size:18px; color:rgb(109, 71, 199)"></i>
+              </div>
+            </div>
+          </div>
         </div>
+      </div>
+
     </div>
+  </div>
+
+      
     
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -243,16 +243,16 @@
                     customisation, that you can use for inspiration.</p>
                 <ul class="lg:pb-5 lg:pt-2 ">
                     <li class="py-1 flex flex-inline">
-                        <i class="material-icons">link</i>
-                        <a class="pl-2" href="">view repo</a>
+                        <i class="fa fa-link"></i>
+                        <a class="pl-2" href="#">view repo</a>
                     </li>
                     <li class="py-1 flex flex-inline">
-                        <i class="material-icons">link</i>
-                        <a class="pl-2" href="">view website</a>
+                        <i class="fa fa-link"></i>
+                        <a class="pl-2" href="#">view website</a>
                     </li>
                     <li class="py-1 flex flex-inline">
-                        <i class="material-icons">link</i>
-                        <a class="pl-2" href="">tech lsit</a>
+                        <i class="fa fa-link"></i>
+                        <a class="pl-2" href="#">tech lsit</a>
                     </li>
                 </ul>
             </div>

--- a/index.html
+++ b/index.html
@@ -229,5 +229,40 @@
         >
       </div>
     </div>
+    
+   <!-- new card in a container -->
+    
+    <div class=" container mx-auto w-auto px-5 py-24 flex flex-inline">
+        <div class="lg:w-1/2 bg-yellow-200 flex flex-inline">
+            <div class="lg:w-2/5 bg-green-200">
+                <h2>IMAGE</h2>
+            </div>
+            <div class="lg:w-3/4 px-5 pt-1 bg-green-500">
+                <h1 class="font-medium text-xl pt-8">awesome-github-profiles</h1>
+                <p class="font-light text-sm py-1">List of GitHub profiles that have awesome
+                    customisation, that you can use for inspiration.</p>
+                <ul class="lg:pb-5 lg:pt-2 ">
+                    <li class="py-1 flex flex-inline">
+                        <i class="material-icons">link</i>
+                        <a class="pl-2" href="">view repo</a>
+                    </li>
+                    <li class="py-1 flex flex-inline">
+                        <i class="material-icons">link</i>
+                        <a class="pl-2" href="">view website</a>
+                    </li>
+                    <li class="py-1 flex flex-inline">
+                        <i class="material-icons">link</i>
+                        <a class="pl-2" href="">tech lsit</a>
+                    </li>
+                </ul>
+            </div>
+
+        </div>
+        <div class="lg:w-1/2 bg-pink-200">
+            <h2>SPACE</h2>
+
+        </div>
+    </div>
+    
   </body>
 </html>


### PR DESCRIPTION
I would add the basic cards in the ` index.html`  file, that has useful information listing all the community organisations projects, with the following information:

project name
project description
repo link
website link
tech stack
status

In large and extra large displays it looks like this 
![lg-disc](https://user-images.githubusercontent.com/35035788/91718367-d6477480-ebb0-11ea-95d6-88d04455756a.PNG)

-------------------------------------------------------------------------------------------------
In medium devices it looks like this
![md-disc](https://user-images.githubusercontent.com/35035788/91718386-df384600-ebb0-11ea-98bf-4920fffcb30f.PNG)


--------------------------------------------------------------------------------------------------
In mobile devices it looks like this
![sm-disc](https://user-images.githubusercontent.com/35035788/91718451-fc6d1480-ebb0-11ea-8f2a-f39a4e67f4c7.PNG)



Added Three icons 
 1. first icon is  for github profile/ personal website

 2. second icons redirects to repository/ github profile

 3.  third just added star icon (we can redirect to any important link in future pushes)
