### PR TITLE
feat: add how to join section

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,6 +200,24 @@
         </div>
       </div>
 
+      <div class="flex flex-col items-center bg-white lg:rounded m-12 py-8 px-4 lg:px-16 lg:max-w-4xl">
+        <h2 class="text-center text-4xl py-5 font-semibold">
+          How to join our
+          <span class="text-teal-600 border-b-2 border-teal-600">community</span>?
+        </h2>
+        <p class="text-center text-xl leading-tight">
+          Raise an issue on the support repo asking to join
+          (<a class="text-blue-500 underline" target="_blank" href="https://github.com/EddieJaoudeCommunity/support/issues?q=is%3Aissue+is%3Aclosed+label%3A%22invite+me+to+the+organisation%22">examples</a>).
+        </p>
+        <a
+          class="mt-5 text-blue-500 bg-transparent border border-solid border-blue-500 hover:bg-blue-500 hover:text-white active:bg-blue-600 font-bold uppercase px-8 py-3 rounded outline-none focus:outline-none mr-1 mb-1"
+          style="transition: all .15s ease"
+          target="_blank"
+          href="https://github.com/EddieJaoudeCommunity/support/issues">
+          Join us.
+        </a>
+      </div>
+
       <!-- Moderator cards -->
       <div class="container my-8 p-5 bg-white rounded-lg">
         <h2 class="text-center text-4xl mb-5 py-5 font-semibold">


### PR DESCRIPTION
closes: #35

![flTM0NDEiC](https://user-images.githubusercontent.com/18630253/92966251-163f0f00-f46f-11ea-96a3-612692b171a4.gif)


For reference, here is the site where I got the "join us" button styles: https://www.creative-tim.com/learning-lab/tailwind-starter-kit/documentation/css/buttons/large/outline

_Note: From the discussion on the issue's comments, this could be improved by the user clicking the button and some back-end process picks it up. This would remove the need for creating the issue and accelerate the process, but for now this is a simpler version 😃._