### PR TITLE
Changed Github redirect in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The available multiple tech branches e.g the Vue.js branch, are for some display
 
 ## Find us on
 - <img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/discord.svg" /> [Discord](https://discord.com/invite/jZQs6Wu)
-- <img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/github.svg" />  [Github](https://github.com/EddieJaoudeCommunity/EddieJaoudeCommunity.github.io)
+- <img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/github.svg" />  [Github](https://github.com/EddieJaoudeCommunity)
 - <img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/youtube.svg" />  [Youtube](https://www.youtube.com/eddiejaoude)
 
 ![Website](https://user-images.githubusercontent.com/61991582/92185956-22aee080-ee4d-11ea-9553-8598c74edde5.png)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/46129076/101287957-99c38e80-3819-11eb-8654-1fcd057e0a61.png)

The Github icon redirect in the README description was corrected from [Github Link 1](https://github.com/EddieJaoudeCommunity/EddieJaoudeCommunity.github.io) to [GithubLink 2](https://github.com/EddieJaoudeCommunity). 
This takes the redirect to the community page and avoids the loop redirect.